### PR TITLE
pin flex-layout version to 2.0.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@angular/common": "4.2.0-rc.1",
     "@angular/compiler": "4.2.0-rc.1",
     "@angular/core": "4.2.0-rc.1",
-    "@angular/flex-layout": "latest",
+    "@angular/flex-layout": "2.0.0-rc.1",
     "@angular/forms": "4.2.0-rc.1",
     "@angular/http": "4.2.0-rc.1",
     "@angular/platform-browser": "4.2.0-rc.1",


### PR DESCRIPTION
ng serve will fail if flex-layout version 6 (latest) is installed. Also tried with 5 with no success.

```
WARNING in ./~/@angular/flex-layout/esm5/core.es5.js
49:11-19 "export 'DOCUMENT' was not found in '@angular/common'

WARNING in ./~/@angular/flex-layout/esm5/core.es5.js
425:63-71 "export 'DOCUMENT' was not found in '@angular/common'

WARNING in ./~/@angular/flex-layout/esm5/core.es5.js
1229:26-34 "export 'DOCUMENT' was not found in '@angular/common'

WARNING in ./~/@angular/flex-layout/esm5/core.es5.js
3090:63-71 "export 'DOCUMENT' was not found in '@angular/common'

WARNING in ./~/@angular/flex-layout/esm5/core.es5.js
3438:63-71 "export 'DOCUMENT' was not found in '@angular/common'

ERROR in ../ng4-animations-preview/node_modules/@angular/flex-layout/flex/typings/flex-offset/flex-offset.d.ts (9,32): Cannot find module '@angular/cdk/bidi'.

ERROR in ../ng4-animations-preview/node_modules/@angular/flex-layout/flex/typings/layout-gap/layout-gap.d.ts (9,32): Cannot find module '@angular/cdk/bidi'.

ERROR in Metadata version mismatch for module ../ng4-animations-preview/node_modules/@angular/flex-layout/typings/index.d.ts, found version 4, expected 3, resolving symbol AppModule in ../ng4-animations-preview/src/app/app.module.ts, resolving symbol AppModule in ../ng4-animations-preview/src/app/app.module.ts

ERROR in ./~/@angular/flex-layout/esm5/flex.es5.js
Module not found: Error: Can't resolve '@angular/cdk/bidi' in '../ng4-animations-preview/node_modules/@angular/flex-layout/esm5'
 @ ./~/@angular/flex-layout/esm5/flex.es5.js 12:0-63
 @ ./~/@angular/flex-layout/esm5/flex-layout.es5.js
 @ ./src/app/app.module.ts
 @ ./src/main.ts
 @ multi webpack-dev-server/client?http://localhost:4201 ./src/main.ts
webpack: Failed to compile.
```